### PR TITLE
feat: use browser's languages by default

### DIFF
--- a/src/plugins/globalization.js
+++ b/src/plugins/globalization.js
@@ -3,13 +3,14 @@
  */
 
 var globalization = {};
+var languages = (navigator.languages) ?  navigator.languages : ["en-US", "en"];
 
 globalization.getPreferredLanguage = function (successCallback, errorCallback) {
-    successCallback({value: "EN"});
+    successCallback({value: languages[1].toUpperCase()});
 };
 
 globalization.getLocaleName = function (successCallback, errorCallback) {
-    successCallback({value: "en-US"});
+    successCallback({value: languages[0]});
 };
 
 globalization.getFirstDayOfWeek = function (successCallback, errorCallback) {


### PR DESCRIPTION
Use Chrome's navigator.languages instead of hardcoded values.
