### PR TITLE
fix: correct getPreferredLanguage

### DIFF
--- a/src/plugins/globalization.js
+++ b/src/plugins/globalization.js
@@ -6,7 +6,7 @@ var globalization = {};
 var languages = (navigator.languages) ?  navigator.languages : ["en-US", "en"];
 
 globalization.getPreferredLanguage = function (successCallback, errorCallback) {
-    successCallback({value: languages[1].toUpperCase()});
+    successCallback({value: languages[0]});
 };
 
 globalization.getLocaleName = function (successCallback, errorCallback) {


### PR DESCRIPTION
Cordova always returns an object like : {"value":"en-US"}

Signed-off-by: Justin Noel <justin.noel@calendee.com>